### PR TITLE
Fixed the sort_records method to satisfy ordered multi-column sorting

### DIFF
--- a/lib/ajax-datatables-rails/orm/active_record.rb
+++ b/lib/ajax-datatables-rails/orm/active_record.rb
@@ -15,10 +15,16 @@ module AjaxDatatablesRails
       end
 
       def sort_records records
-        sort_by = connected_columns.each_with_object([]) do |(column, column_def), queries|
-          order = datatable.order(:column_index, column.index)
-          queries << order.query(column.sort_query) if order
+        sort_by = datatable.orders.inject([]) do |queries, column_def|
+          column = column_def.column
+          queries << column_def.query(column.sort_query) if column
         end
+
+        #sort_by = connected_columns.each_with_object([]) do |(column, column_def), queries|
+        #  order = datatable.order(:column_index, column.index)
+        #  queries << order.query(column.sort_query) if order
+        #end
+
         records.order(sort_by.join(", "))
       end
 

--- a/lib/ajax-datatables-rails/orm/active_record.rb
+++ b/lib/ajax-datatables-rails/orm/active_record.rb
@@ -19,12 +19,6 @@ module AjaxDatatablesRails
           column = column_def.column
           queries << column_def.query(column.sort_query) if column
         end
-
-        #sort_by = connected_columns.each_with_object([]) do |(column, column_def), queries|
-        #  order = datatable.order(:column_index, column.index)
-        #  queries << order.query(column.sort_query) if order
-        #end
-
         records.order(sort_by.join(", "))
       end
 


### PR DESCRIPTION
It is possible to order columns on multiple fields by SHIFT+Clicking on column headers but actual implementation loose the sort order by not relying on the order of the columns in the Datatables "order" array.
